### PR TITLE
Use NuGet Packages instead of local dependencies

### DIFF
--- a/TypeInjections/Tool/Tool.fsproj
+++ b/TypeInjections/Tool/Tool.fsproj
@@ -15,24 +15,13 @@
 
 
     <ItemGroup>
-        <Reference Include="Boogie.Core, Version=2.15.x, Culture=neutral, PublicKeyToken=null">
-            <HintPath>..\..\dafny\Boogie.Core.dll</HintPath>
-        </Reference>
-        <Reference Include="Dafny, Version=3.6.x, Culture=neutral, PublicKeyToken=null">
-            <HintPath>..\..\dafny\Dafny.dll</HintPath>
-        </Reference>
-        <Reference Include="DafnyPipeline, Version=3.6.x, Culture=neutral, PublicKeyToken=null">
-            <HintPath>..\..\dafny\DafnyPipeline.dll</HintPath>
-        </Reference>
-        <Reference Include="Boogie.BaseTypes, Version=2.15.x, Culture=neutral, PublicKeyToken=null">
-            <HintPath>..\..\dafny\Boogie.BaseTypes.dll</HintPath>
-        </Reference>
-        <Reference Include="Boogie.ExecutionEngine, Version=2.15.x, Culture=neutral, PublicKeyToken=null">
-            <HintPath>..\..\dafny\Boogie.ExecutionEngine.dll</HintPath>
-        </Reference>
-        <Reference Include="Boogie.CodeContractsExtender, Version=2.15.x, Culture=neutral, PublicKeyToken=null">
-            <HintPath>..\..\dafny\Boogie.CodeContractsExtender.dll</HintPath>
-        </Reference>
+        <PackageReference Include="Boogie.CodeContractsExtender" Version="2.15.7" />
+        <PackageReference Include="Boogie.Core" Version="2.15.7" />
+        <PackageReference Include="Boogie.ExecutionEngine" Version="2.15.7" />
+        <PackageReference Include="CommandLineParser.FSharp" Version="2.9.2-ci-210" />
+        <PackageReference Include="DafnyPipeline" Version="3.6.0.40511" />
+        <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
+        <PackageReference Include="Microsoft.Z3" Version="4.10.1" />
     </ItemGroup>
 
 </Project>

--- a/TypeInjections/TypeInjections/TypeInjections.fsproj
+++ b/TypeInjections/TypeInjections/TypeInjections.fsproj
@@ -21,23 +21,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Reference Include="Boogie.Core, Version=2.15.x, Culture=neutral, PublicKeyToken=null">
-            <HintPath>..\..\dafny\Boogie.Core.dll</HintPath>
-        </Reference>
-        <Reference Include="Dafny, Version=3.6.x, Culture=neutral, PublicKeyToken=null">
-            <HintPath>..\..\dafny\Dafny.dll</HintPath>
-        </Reference>
-        <Reference Include="DafnyPipeline, Version=3.6.x, Culture=neutral, PublicKeyToken=null">
-            <HintPath>..\..\dafny\DafnyPipeline.dll</HintPath>
-        </Reference>
-        <Reference Include="Boogie.BaseTypes, Version=2.15.x, Culture=neutral, PublicKeyToken=null">
-          <HintPath>..\..\dafny\Boogie.BaseTypes.dll</HintPath>
-        </Reference>
-        <Reference Include="Boogie.ExecutionEngine, Version=2.15.x, Culture=neutral, PublicKeyToken=null">
-            <HintPath>..\..\dafny\Boogie.ExecutionEngine.dll</HintPath>
-        </Reference>      
-        <Reference Include="Boogie.CodeContractsExtender, Version=2.15.x, Culture=neutral, PublicKeyToken=null">
-          <HintPath>..\..\dafny\Boogie.CodeContractsExtender.dll</HintPath>
-        </Reference>
+        <PackageReference Include="Boogie.CodeContractsExtender" Version="2.15.7" />
+        <PackageReference Include="Boogie.Core" Version="2.15.7" />
+        <PackageReference Include="Boogie.ExecutionEngine" Version="2.15.7" />
+        <PackageReference Include="CommandLineParser.FSharp" Version="2.9.2-ci-210" />
+        <PackageReference Include="DafnyPipeline" Version="3.6.0.40511" />
+        <PackageReference Include="Microsoft.Z3" Version="4.10.1" />
     </ItemGroup>
+    
 </Project>

--- a/TypeInjections/TypeInjections/Utils.fs
+++ b/TypeInjections/TypeInjections/Utils.fs
@@ -129,30 +129,7 @@ module Utils =
         // preparations, adapted from DafnyDriver.Main
         let reporter = ConsoleErrorReporter()
         let options = DafnyOptions()
-        log "***** searching for DafnyPrelude.bpl"
-        (* Dafny initialization always call Boogie initialization, which depends on loading DafnyPrelude.bpl, a Boogie file
-               implementing the Dafny built-ins. Even though we will not run Boogie, we need to go through this step.
-               But Dafny cannot find the file in dafny/Binaries because it uses the location of the current program to locate it.
-               So we copy the file into the current project and point Dafny to it.
-            *)
         // get the directory of the running program
-        let codebase = location
-        //ToDo: the orElse branch could only be checked if the first test failed
-        let dafnyPrelude =
-            // When using the binary installation of Dafny:
-            findFile (codebase, "dafny", "DafnyPrelude.bpl")
-            // When using Dafny built from source:
-            |> Option.orElse (findFile (codebase, "dafny/Binaries", "DafnyPrelude.bpl"))
-            |> Option.get
-        Console.WriteLine(dafnyPrelude)
-        let dafnyPreludeDir =
-            findDirectory (codebase, "dafny", "DafnyPrelude.bpl")
-            |> Option.get
-        logObject "found in: {0}" dafnyPreludeDir
-        log "***** initialising Dafny"
-        options.DafnyPrelude <- dafnyPrelude
-        // Disable module reveals / provides scopes, otherwise we get e.g. lemmas with empty bodies.
-        options.DisableScopes <- true
         DafnyOptions.Install(options)
         log "***** Dafny initialised"
         reporter


### PR DESCRIPTION
To make typeCart a dotnet tool, we need to use dependencies found on NuGet instead of relying on local files. Now to initialize Dafny, we no longer need to hunt for .dll file in local computer (since we now use NuGet package)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
