### PR TITLE
removing unnecessary z3 package, adding tool metadata

### DIFF
--- a/TypeInjections/Tool/Make_Tool.md
+++ b/TypeInjections/Tool/Make_Tool.md
@@ -1,0 +1,43 @@
+## How to make dotnet tool
+1. open `.fsproj` for the project you want to make a .NET tool for and include the following:
+```xml
+<PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>typeCart</RootNamespace>
+
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>typecart</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+
+    <PackageId>typecart</PackageId>
+    <Version>1.0.0</Version>
+    <Authors> [ADD_NAMES] </Authors>
+    <Company> [ADD_COMPANY] </Company>
+
+</PropertyGroup>
+```
+2. Open the terminal in the directory with `.fsproj` file
+3. Build the project and create NuGet package
+```zsh
+$ dotnet pack
+```
+4. Deploy the tool on the local system using install global tool command
+```zsh
+$ dotnet tool install --global --add-source ./nupkg typecart
+```
+5. (optional) Publish tool to internet (NuGet library)
+    - Create account on [NuGet.org](https://www.nuget.org/)
+    - Click on username in top right corner and go to [API Keys](https://www.nuget.org/account/apikeys)
+    - Create API key
+        * Give KeyName
+        * Set globe pattern to `*`
+        * Create API
+        * Copy API Key
+    - (While still in directory with `.fsproj`) publish nupkg file
+    ```zsh
+    $ dotnet nuget push typecart.[VERSION_HERE].nupkg --api-key [API_KEY_HERE] --source https://api.nuget.org/v3/index.json
+    ```
+## How users can download tool to use
+1. If user has .NET SDK installed: go to [typeCart's Nuget Package](https://www.nuget.org/packages/typecart) page and run terminal command
+2. [Coming soon] We will soon publish a typeCart CLI that can run independently of .NET SDK, not sure where we will host this package

--- a/TypeInjections/Tool/Tool.fsproj
+++ b/TypeInjections/Tool/Tool.fsproj
@@ -3,25 +3,32 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
+
+        <PackAsTool>true</PackAsTool>
+        <ToolCommandName>typecart</ToolCommandName>
+        <PackageOutputPath>./nupkg</PackageOutputPath>
+        <PackageId>typecart</PackageId>
+        <Version>1.0.0</Version>
+        <Authors> </Authors>
+        <Company> </Company>
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Include="Tool.fs" />
+        <Compile Include="Tool.fs"/>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\TypeInjections\TypeInjections.fsproj" />
+        <ProjectReference Include="..\TypeInjections\TypeInjections.fsproj"/>
     </ItemGroup>
 
 
     <ItemGroup>
-        <PackageReference Include="Boogie.CodeContractsExtender" Version="2.15.7" />
-        <PackageReference Include="Boogie.Core" Version="2.15.7" />
-        <PackageReference Include="Boogie.ExecutionEngine" Version="2.15.7" />
-        <PackageReference Include="CommandLineParser.FSharp" Version="2.9.2-ci-210" />
-        <PackageReference Include="DafnyPipeline" Version="3.6.0.40511" />
-        <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
-        <PackageReference Include="Microsoft.Z3" Version="4.10.1" />
+        <PackageReference Include="Boogie.CodeContractsExtender" Version="2.15.7"/>
+        <PackageReference Include="Boogie.Core" Version="2.15.7"/>
+        <PackageReference Include="Boogie.ExecutionEngine" Version="2.15.7"/>
+        <PackageReference Include="CommandLineParser.FSharp" Version="2.9.2-ci-210"/>
+        <PackageReference Include="DafnyPipeline" Version="3.6.0.40511"/>
+        <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182"/>
     </ItemGroup>
 
 </Project>

--- a/TypeInjections/TypeInjections/TypeInjections.fsproj
+++ b/TypeInjections/TypeInjections/TypeInjections.fsproj
@@ -7,26 +7,25 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Include="Utils.fs" />
-        <Compile Include="InjectionIO.fs" />
-        <Compile Include="YIL.fs" />
-        <Compile Include="Traverser.fs" />
-        <Compile Include="Analysis.fs" />
-        <Compile Include="DafnyToYIL.fs" />
-        <Compile Include="Diff.fs" />
-        <Compile Include="Differ.fs" />
-        <Compile Include="Translation.fs" />
-        <Compile Include="Typecart.fs" />
-        <Compile Include="Program.fs" />
+        <Compile Include="Utils.fs"/>
+        <Compile Include="InjectionIO.fs"/>
+        <Compile Include="YIL.fs"/>
+        <Compile Include="Traverser.fs"/>
+        <Compile Include="Analysis.fs"/>
+        <Compile Include="DafnyToYIL.fs"/>
+        <Compile Include="Diff.fs"/>
+        <Compile Include="Differ.fs"/>
+        <Compile Include="Translation.fs"/>
+        <Compile Include="Typecart.fs"/>
+        <Compile Include="Program.fs"/>
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Boogie.CodeContractsExtender" Version="2.15.7" />
-        <PackageReference Include="Boogie.Core" Version="2.15.7" />
-        <PackageReference Include="Boogie.ExecutionEngine" Version="2.15.7" />
-        <PackageReference Include="CommandLineParser.FSharp" Version="2.9.2-ci-210" />
-        <PackageReference Include="DafnyPipeline" Version="3.6.0.40511" />
-        <PackageReference Include="Microsoft.Z3" Version="4.10.1" />
+        <PackageReference Include="Boogie.CodeContractsExtender" Version="2.15.7"/>
+        <PackageReference Include="Boogie.Core" Version="2.15.7"/>
+        <PackageReference Include="Boogie.ExecutionEngine" Version="2.15.7"/>
+        <PackageReference Include="CommandLineParser.FSharp" Version="2.9.2-ci-210"/>
+        <PackageReference Include="DafnyPipeline" Version="3.6.0.40511"/>
     </ItemGroup>
-    
+
 </Project>


### PR DESCRIPTION
Matthias reviewed dependency list in fsproj and correctly pointed out that z3 package is unnecessary. To make dotnet tool, certain metadata in .fsproj is required. This data is added

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
