### PR TITLE
convert resources into EmbeddedResource

### DIFF
--- a/TypeInjections/TypeInjections/Resources/UsingResources.txt
+++ b/TypeInjections/TypeInjections/Resources/UsingResources.txt
@@ -1,0 +1,17 @@
+How to make resource file
+1. 'Add file' to Resources folder (need to make new file, 
+can't figure out how to do this for imported dafny files)
+2. Right click on created file and go to 'properties'
+3. Change 'Build Action' to 'Embedded Resource'
+4. Change 'Copy to output directory' to 'Copy Always'
+
+How to access resource file
+1. get current assemby object: 
+let asmb = Assembly.GetExecutingAssembly();
+2. inspect list of assembly resources for your file's assembly name:
+let listOfNames = asmb.GetManifestResourceNames()
+3. Create stream object for Assembly file
+let stream = asmb.GetManifestResourceStream([ASSEMBLY_NAME_HERE])
+4. Read stream
+let reader = new StreamReader(stream)
+reader.ReadToEnd()

--- a/TypeInjections/TypeInjections/TypeInjections.fsproj
+++ b/TypeInjections/TypeInjections/TypeInjections.fsproj
@@ -1,5 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
@@ -7,6 +6,15 @@
     </PropertyGroup>
 
     <ItemGroup>
+
+        <Content Include="Resources\UsingResources.txt"/>
+        <EmbeddedResource Include="Resources\MapBuiltinTypes.dfy">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </EmbeddedResource>
+        <EmbeddedResource Include="Resources\RelateBuiltinTypes.dfy">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </EmbeddedResource>
+        
         <Compile Include="Utils.fs"/>
         <Compile Include="InjectionIO.fs"/>
         <Compile Include="YIL.fs"/>
@@ -19,7 +27,6 @@
         <Compile Include="Typecart.fs"/>
         <Compile Include="Program.fs"/>
     </ItemGroup>
-
     <ItemGroup>
         <PackageReference Include="Boogie.CodeContractsExtender" Version="2.15.7"/>
         <PackageReference Include="Boogie.Core" Version="2.15.7"/>
@@ -27,5 +34,4 @@
         <PackageReference Include="CommandLineParser.FSharp" Version="2.9.2-ci-210"/>
         <PackageReference Include="DafnyPipeline" Version="3.6.0.40511"/>
     </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Solves the issue of including resources in TypeInjections project. Resource files are converted into assembly at runtime by `TypeInjections.fsproj`. Rachel will be able to edit these files just as any regular .dfy file. Steps to make another resource file are included in `Resources/UsingResources.txt`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
