### PR TITLE
Add typeCart API, Implement ignore feature

### DIFF
--- a/TypeInjections/Tool.Test/ToolTests.fs
+++ b/TypeInjections/Tool.Test/ToolTests.fs
@@ -21,23 +21,7 @@ module IOTests =
         |> ignore
     //TODO assert type of error is correct
 
-    [<Test>]
-    // no dafny files given in input
-    let NoDafnyTest () =
-        // folder has only txt file
-        let argsTxt =
-            [ $"{resourcePath}/Local/NoDafnyTest/OnlyText" ]
-
-        Assert.Catch(fun () -> Tool.checkInputs argsTxt)
-        |> ignore
-        //TODO assert type of error is correct
-
-        // folder is empty
-        let argsEmpty =
-            [ $"{resourcePath}/Local/NoDafnyTest/Empty" ]
-
-        Assert.Catch(fun () -> Tool.checkInputs argsEmpty) |> ignore
-    //TODO assert type of error is correct
+    //TODO assert that folder without dafny gives proper error
 
     [<Test>]
     // with correct inputs, typecart local works

--- a/TypeInjections/Tool/Make_Tool.md
+++ b/TypeInjections/Tool/Make_Tool.md
@@ -36,7 +36,7 @@ $ dotnet tool install --global --add-source ./nupkg typecart
         * Copy API Key
     - (While still in directory with `.fsproj`) publish nupkg file
     ```zsh
-    $ dotnet nuget push typecart.[VERSION_HERE].nupkg --api-key [API_KEY_HERE] --source https://api.nuget.org/v3/index.json
+    $ dotnet nuget push nupkg/typecart.[VERSION_HERE].nupkg --api-key [API_KEY_HERE] --source https://api.nuget.org/v3/index.json
     ```
 ## How users can download tool to use
 1. If user has .NET SDK installed: go to [typeCart's Nuget Package](https://www.nuget.org/packages/typecart) page and run terminal command

--- a/TypeInjections/Tool/README.md
+++ b/TypeInjections/Tool/README.md
@@ -8,7 +8,7 @@ typeCart CLI offers two ways to compare projects:
       * `-p` `--print` Tell typeCart which folder to print out generated files
   * Additional Options
     * `-i` `--ignore` Give list of filenames to ignore when running typeCart
-    * (coming soon) `-e` `--entrypoint` Specify certain file(s) to run typeCart on 
+    * `-t` `--typecartignore` Input the absolute path to .typecartignore file 
 - git commits in repository: `$ typecart git [--old <commit>]  [--new <commit>] [--print <path>] [--clone <git URL>] [--ignore <names>]`
   * Required options 
     * `-o` `--old` Give the absolute path of old project
@@ -17,6 +17,7 @@ typeCart CLI offers two ways to compare projects:
   * Additional Options
     * `-c` `--clone` Provide git URL to checkout commits 
     * `-i` `--ignore` Give list of filenames to ignore when running typeCart 
+    * `-t` `--typecartignore` Input the absolute path to .typecartignore file
     * (coming soon) `-e` `--entrypoint` Specify certain file(s) to run typeCart on
 
 External Libraries used in Tool project

--- a/TypeInjections/Tool/README.md
+++ b/TypeInjections/Tool/README.md
@@ -1,21 +1,23 @@
 ## typeCart features
 typeCart CLI offers two ways to compare projects:
 - projects on local computer:
-  `$ typecart local [--old <path>] [--new <path>] [--print <path>] [--file <names>]`
+  `$ typecart local [--old <path>] [--new <path>] [--print <path>] [--ignore <names>]`
     * Required Options
       * `-o` `--old` Give the absolute path of old project
       * `-n` `--new` Give the absolute path of new project
       * `-p` `--print` Tell typeCart which folder to print out generated files
   * Additional Options
+    * `-i` `--ignore` Give list of filenames to ignore when running typeCart
     * (coming soon) `-e` `--entrypoint` Specify certain file(s) to run typeCart on 
-- git commits in repository: `$ typecart git [--old <commit>]  [--new <commit>] [--print <path>] [--clone <git URL>] [--file <names>]`
+- git commits in repository: `$ typecart git [--old <commit>]  [--new <commit>] [--print <path>] [--clone <git URL>] [--ignore <names>]`
   * Required options 
     * `-o` `--old` Give the absolute path of old project
     * `-n` `--new` Give the absolute path of new project
     * `-p` `--print` Tell typeCart which folder to print out generated files
   * Additional Options
     * `-c` `--clone` Provide git URL to checkout commits 
-    * `-e` `--entrypoint` Specify certain file(s) to run typeCart on
+    * `-i` `--ignore` Give list of filenames to ignore when running typeCart 
+    * (coming soon) `-e` `--entrypoint` Specify certain file(s) to run typeCart on
 
 External Libraries used in Tool project
 * [CommandLineParser.fsharp](https://github.com/commandlineparser/commandline) Popular .NET command line parsing library

--- a/TypeInjections/Tool/README.md
+++ b/TypeInjections/Tool/README.md
@@ -8,7 +8,6 @@ typeCart CLI offers two ways to compare projects:
       * `-p` `--print` Tell typeCart which folder to print out generated files
   * Additional Options
     * `-i` `--ignore` Give list of filenames to ignore when running typeCart
-    * `-t` `--typecartignore` Input the absolute path to .typecartignore file 
 - git commits in repository: `$ typecart git [--old <commit>]  [--new <commit>] [--print <path>] [--clone <git URL>] [--ignore <names>]`
   * Required options 
     * `-o` `--old` Give the absolute path of old project
@@ -16,8 +15,7 @@ typeCart CLI offers two ways to compare projects:
     * `-p` `--print` Tell typeCart which folder to print out generated files
   * Additional Options
     * `-c` `--clone` Provide git URL to checkout commits 
-    * `-i` `--ignore` Give list of filenames to ignore when running typeCart 
-    * `-t` `--typecartignore` Input the absolute path to .typecartignore file
+    * `-i` `--ignore` Give list of filenames to ignore when running typeCart
     * (coming soon) `-e` `--entrypoint` Specify certain file(s) to run typeCart on
 
 External Libraries used in Tool project

--- a/TypeInjections/TypeInjections/Typecart.fs
+++ b/TypeInjections/TypeInjections/Typecart.fs
@@ -59,6 +59,7 @@ module Typecart =
                 | _ -> []
         
         let isFilenameIgnored (fileName: string) =
+            let test = ignorePatterns @ currDirIgnores
             List.fold (fun (ignored: bool) (pattern: Regex) -> (pattern.IsMatch fileName) || ignored) false (ignorePatterns @ currDirIgnores)
         
         // constructor that helps read in ignore patterns from file
@@ -80,7 +81,7 @@ module Typecart =
         new(d: DirectoryInfo, ignorePatternsFile: string option) = TypecartProject(Utils.D d, ignorePatternsFile)
         // generic entrypoint when we don't know whether path is a file or directory
         new(path: string, ignorePatterns: string option) = TypecartProject(Utils.parseSystemPath(path), ignorePatterns)
-                
+        new(path: string, ignorePatterns: string list) = TypecartProject(Utils.parseSystemPath(path), List.map makeRegex ignorePatterns)
         // list of subdirectories of currenct project. Empty when project is just a file.
         member this.subDirectories =
             match project with


### PR DESCRIPTION
Now typeCart tool directly calls typeCart API. Additionally, users can now list out the name of files they want typeCart to ignore. 

@ruijiefang allowed for users to input an absolute path of where a .typecartignore file is, will implement in next PR (need to think of a good option name)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
