### PR TITLE
Fix missing includes of old.dfy and new.dfy

### DIFF
--- a/TypeInjections/TypeInjections/Analysis.fs
+++ b/TypeInjections/TypeInjections/Analysis.fs
@@ -69,7 +69,7 @@ module Analysis =
       override this.ToString() = "adding imports of " + (Utils.listToString(imps, ", "))
       override this.prog(prog: Program) =
           let prog' = this.progDefault(prog)
-          let is = incls |> List.map (fun i -> Include(Path ["joint.dfy"]))
+          let is = incls |> List.map (fun i -> Include(Path [i]))
           {prog' with decls = is @ prog'.decls}
       override this.decl(ctx: Context, decl: Decl) =
           match decl with


### PR DESCRIPTION
*Description of changes:*
Fixes `Error: module Old does not exist` and `Error: module New does not exist` errors by adding `include "old.dfy"` and `include "new.dfy"` in the correct place.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
