### PR TITLE
Generate lemma calls in proof sketches 

### DIFF
--- a/TypeInjections/TypeInjections/Analysis.fs
+++ b/TypeInjections/TypeInjections/Analysis.fs
@@ -156,25 +156,6 @@ module Analysis =
         member this.gather(prog: Program) =
             this.progDefault(prog) |> ignore
             result
-    
-    /// Returns a list of LocalDecls that an Expr uses.
-    type GatherLocalDecls() =
-        inherit Traverser.Identity()
-        
-        let mutable result: LocalDecl list = []
-        
-        override this.expr(ctx: Context, e: Expr) =
-            match e with
-            | EVar n ->
-                let ldO = ctx.lookupLocalDeclO(n)
-                if ldO.IsSome then
-                    result <- ldO.Value :: result
-            | _ -> ()
-            this.exprDefault(ctx, e)
-        
-        member this.gather(ctx: Context, e: Expr): LocalDecl list =
-            this.expr(ctx, e) |> ignore
-            result
 
     /// filters declarations by applying a predicate to their path;
     /// prefix imports to removed declarations

--- a/TypeInjections/TypeInjections/Analysis.fs
+++ b/TypeInjections/TypeInjections/Analysis.fs
@@ -473,7 +473,7 @@ module Analysis =
             let rcEs (es: Expr list) = List.map rcE es
             let tryRemovingReceiver (r: Receiver) (m: Path) (result: Expr) =
                 match r with
-                | StaticReceiver ct ->
+                | StaticReceiver _ ->
                     if this.path(ctx, m).names.Length = 1 then
                         result  // remove the receiver completely
                     else

--- a/TypeInjections/TypeInjections/Analysis.fs
+++ b/TypeInjections/TypeInjections/Analysis.fs
@@ -156,6 +156,25 @@ module Analysis =
         member this.gather(prog: Program) =
             this.progDefault(prog) |> ignore
             result
+    
+    /// Returns a list of LocalDecls that an Expr uses.
+    type GatherLocalDecls() =
+        inherit Traverser.Identity()
+        
+        let mutable result: LocalDecl list = []
+        
+        override this.expr(ctx: Context, e: Expr) =
+            match e with
+            | EVar n ->
+                let ldO = ctx.lookupLocalDeclO(n)
+                if ldO.IsSome then
+                    result <- ldO.Value :: result
+            | _ -> ()
+            this.exprDefault(ctx, e)
+        
+        member this.gather(ctx: Context, e: Expr): LocalDecl list =
+            this.expr(ctx, e) |> ignore
+            result
 
     /// filters declarations by applying a predicate to their path;
     /// prefix imports to removed declarations

--- a/TypeInjections/TypeInjections/Analysis.fs
+++ b/TypeInjections/TypeInjections/Analysis.fs
@@ -325,8 +325,9 @@ module Analysis =
                 match d with
                 | Import it ->
                     match it with
-                    | ImportDefault _ ->
-                        this.declDefault(ctx, d)
+                    | ImportDefault (_, l) ->
+                        this.addPath(ctx.currentDecl, l.name, l)
+                        [ d ]
                     | ImportEquals(_, l, r) ->
                         // Special case: we want the LHS name to map to the actual path.
                         // We do not want to call this.declDefault() which calls this.path().

--- a/TypeInjections/TypeInjections/DafnyToYIL.fs
+++ b/TypeInjections/TypeInjections/DafnyToYIL.fs
@@ -724,7 +724,7 @@ module DafnyToYIL =
             if p.names.Item(0) = DafnySystem then
                 let e =
                     match r with
-                    | Y.ObjectReceiver (e) -> e
+                    | Y.ObjectReceiver (e, _) -> e
                     | Y.StaticReceiver _ -> error "Unknown receiver"
 
                 if p.names.Item(1).StartsWith(DafnyTuple) then
@@ -1207,7 +1207,7 @@ module DafnyToYIL =
         | :? StaticReceiverExpr as r ->
             let ct = classType (r.Type)
             Y.StaticReceiver(ct)
-        | _ -> Y.ObjectReceiver(expr r)
+        | _ -> Y.ObjectReceiver(expr r, tp r.Type)
 
     and unqualifyReceiver (recv: Y.Receiver) : Y.Receiver =
         match recv with

--- a/TypeInjections/TypeInjections/Translation.fs
+++ b/TypeInjections/TypeInjections/Translation.fs
@@ -386,16 +386,16 @@ module Translation =
                     // x_N == forward(x_O)
                     EEqual(localDeclTerm inN, oldToNew)
                 else
-                    match newToOld with
+                    match oldToNew with
                     | EFun (vars, cond, _, body) ->
                         // function f: A -> B
-                        // NewToOld is (a_O: A_O) => B_backward(f_N(A_forward(a_O)))
-                        // forall a_O: A_O :: B_backward(f_N(A_forward(a_O))) == f_O(A_O)
+                        // oldToNew is (a_N: A_N) => B_forward(f_O(A_backward(a_N)))
+                        // forall a_N: A_N :: f_N(A_N) == B_forward(f_O(A_backward(a_O)))
                         EQuant(
                             Forall,
                             vars,
                             Option.map fst cond,
-                            EEqual(body, EAnonApply(localDeclTerm inO, List.map localDeclTerm vars))
+                            EEqual(EAnonApply(localDeclTerm inN, List.map localDeclTerm vars), body)
                         )
                     | _ ->
                         // not a function

--- a/TypeInjections/TypeInjections/Traverser.fs
+++ b/TypeInjections/TypeInjections/Traverser.fs
@@ -385,7 +385,7 @@ module Traverser =
         default this.receiver(ctx, rcv) =
             match rcv with
             | StaticReceiver ct -> StaticReceiver(this.classType (ctx, ct))
-            | ObjectReceiver e -> ObjectReceiver(this.expr (ctx, e))
+            | ObjectReceiver (e, tp) -> ObjectReceiver(this.expr (ctx, e), this.tp (ctx, tp))
 
         /// transforms a constructor in a datatype
         abstract member constructor : Context * cons: DatatypeConstructor -> DatatypeConstructor

--- a/TypeInjections/TypeInjections/Traverser.fs
+++ b/TypeInjections/TypeInjections/Traverser.fs
@@ -235,7 +235,14 @@ module Traverser =
             | ESeqSelect (s, t, elem, frI, toI) -> ESeqSelect(rcE s, rcT t, elem, rcEo frI, rcEo toI)
             | ESeqUpdate (s, i, e) -> ESeqUpdate(rcE s, rcE i, rcE e)
             | EToString es -> EToString(rcEs es)
-            | EArray (t, dim) -> EArray(rcT t, dim)
+            | EArray (t, dim, init) ->
+                let initT =
+                    match init with
+                    | Uninitialized -> Uninitialized
+                    | ValueList es -> ValueList(rcEs es)
+                    | ComprehensionLambda e -> ComprehensionLambda(rcE e)
+
+                EArray(rcT t, dim, initT)
             | EMultiSelect (a, i) -> EMultiSelect(rcE a, i)
             | EArrayUpdate (a, i, e) -> EArrayUpdate(rcE a, i, rcE e)
             | EMapKeys m -> EMapKeys(rcE m)

--- a/TypeInjections/TypeInjections/Typecart.fs
+++ b/TypeInjections/TypeInjections/Typecart.fs
@@ -233,9 +233,15 @@ module Typecart =
                     .Pipeline(combinePipeline)
                     .apply (
                         combineYIL,
-                        [ jointYILpreserved
-                          oldYILpreserved
-                          newYILpreserved ]
+                        [ Analysis
+                            .WrapTopDecls(jointPrefix)
+                              .prog jointYILpreserved
+                          Analysis
+                              .WrapTopDecls(oldOrNewPrefix (true))
+                              .prog oldYILpreserved
+                          Analysis
+                              .WrapTopDecls(oldOrNewPrefix (false))
+                              .prog newYILpreserved ]
                     )
 
             outputWriter.processCombine (combineYILresult)

--- a/TypeInjections/TypeInjections/YIL.fs
+++ b/TypeInjections/TypeInjections/YIL.fs
@@ -695,7 +695,7 @@ module YIL =
         // reference to a static child in a class/module
         | StaticReceiver of ClassType
         // reference to a dynamic child in an object of a class/datatype
-        | ObjectReceiver of Expr
+        | ObjectReceiver of Expr * Type
 
     and Quantifier =
         | Forall
@@ -1937,7 +1937,7 @@ module YIL =
 
             match rcv with
             | StaticReceiver (ct) -> this.classType (ct) |> dot // ClassType --> path, tpargs
-            | ObjectReceiver (e) -> this.exprWithPrecedence e 11 pctx |> dot // e should be a primary expression
+            | ObjectReceiver (e, _) -> this.exprWithPrecedence e 11 pctx |> dot // e should be a primary expression
 
         member this.caseStatement (case: Case) (pctx: Context) =
             // Remove the extra braces

--- a/TypeInjections/TypeInjections/YIL.fs
+++ b/TypeInjections/TypeInjections/YIL.fs
@@ -1040,6 +1040,9 @@ module YIL =
             Context(prog, currentDecl, tpvars, List.append vars ds, pos, importPaths, thisDecl)
         // abbreviation for a single non-ghost local variable
         member this.add(n: string, t: Type) : Context = this.add [ LocalDecl(n, t, false) ]
+        // add old or new suffix to all LocalDecls
+        member this.translateLocalDeclNames(f: string -> string) : Context =
+            Context(prog, currentDecl, tpvars, List.map (fun (ld: LocalDecl) -> LocalDecl(f ld.name, ld.tp, ld.ghost)) vars, pos, importPaths, thisDecl)
         
         // set the LocalDecl for "this"
         member this.setThisDecl(d: LocalDecl) : Context =


### PR DESCRIPTION
This is a big change so making a pull request for it to be easier to track.

*Description of changes:*

- Generate a lemma call for each method call in proof sketches (the old implementation)
- Store the `Type` of the `Expr` in `ObjectReceiver`
- Maintain the local variables and type variables correctly during `Translation`
- Fix some missing parentheses when printing out expressions with lemma calls
- Add line breaks for expressions with lemma calls

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
