### PR TITLE
Omit parentheses if a datatype constructor doesn't have a parameter

### DIFF
--- a/TypeInjections/TypeInjections/YIL.fs
+++ b/TypeInjections/TypeInjections/YIL.fs
@@ -1404,7 +1404,10 @@ module YIL =
             + (this.expr (fst c) pctx)
 
         member this.datatypeConstructor(c: DatatypeConstructor, pctx: Context) =
-            c.name + (this.localDeclsBr (c.ins, true))
+            if c.ins.IsEmpty then 
+                c.name
+            else
+                c.name + (this.localDeclsBr (c.ins, true))
 
         member this.tps(ts: Type list) =
             if ts.IsEmpty then


### PR DESCRIPTION
The change removes parentheses from `datatype` constructors with no parameters in the pretty-printer.
For example, instead of
```
datatype Friends = Agnes() | Agatha() | Jermaine() | Jack()
```
It prints,
```
datatype Friends = Agnes | Agatha | Jermaine | Jack
```