### PR TITLE
Remove empty block from inductive datatypes in the pretty-printer

### DIFF
--- a/TypeInjections/TypeInjections/YIL.fs
+++ b/TypeInjections/TypeInjections/YIL.fs
@@ -1259,7 +1259,7 @@ module YIL =
                 + (this.tpvars true false tpvs)
                 + (if consS.IsEmpty then "" else " = ")
                 + listToString (consS, " | ")
-                + (decls ds)
+                + (if ds.IsEmpty then "" else decls ds)
             | Class (n, isTrait, tpvs, p, ds, a) ->
                 if isTrait then "trait " else "class "
                 + (this.meta a)


### PR DESCRIPTION
Another minor change. This PR removes empty blocks from datatypes while pretty-printing.
For example, before the change:
```
datatype Friends = Agnes | Agatha | Jermaine | Jack {
}
```
After the change:
```
datatype Friends = Agnes | Agatha | Jermaine | Jack
```